### PR TITLE
Bump the upper limit on compatible build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginVersion = 1.1.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 222
-pluginUntilBuild = 223.*
+pluginUntilBuild = 231.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IU


### PR DESCRIPTION
Replicates the direct edit I made to the generated plugin.xml to get it working in 2023.1 

Sorry if this isn't the right change, I'm guessing this is the appropriate place to fix it.